### PR TITLE
python 3 compatability and trigger source as a property instead of ct…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def main():
     """Main method collecting all the parameters to setup."""
     name = "sardana-albaem"
 
-    version = "0.0.7"
+    version = "1.0.0"
 
     description = "AlbaEM Sardana Controller"
 
@@ -36,7 +36,7 @@ def main():
 
     license = "GPLv3"
 
-    url = "http://www.maxiv.lu.se"
+    url = "https://github.com/MaxIV-KitsControls/sardana-albaem"
 
     packages = find_packages()
 


### PR DESCRIPTION
- added python 3 compatibility.
- `ExtTriggerInput` as property instead of attribute because this needs to be changed in `LoadOne` before each scan to make sure the electrometer has the right trigger in setting.